### PR TITLE
Verbosity level for resctrl and perf logs

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -18,7 +18,6 @@ package manager
 import (
 	"flag"
 	"fmt"
-	"github.com/opencontainers/runc/libcontainer/cgroups/fs2"
 	"net/http"
 	"os"
 	"path"
@@ -46,6 +45,7 @@ import (
 	"github.com/google/cadvisor/utils/sysfs"
 	"github.com/google/cadvisor/version"
 	"github.com/google/cadvisor/watcher"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fs2"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/intelrdt"
@@ -957,11 +957,11 @@ func (m *manager) createContainerLocked(containerName string, watchSource watche
 
 	resctrlPath, err := intelrdt.GetIntelRdtPath(containerName)
 	if err != nil {
-		klog.Warningf("Error getting resctrl path: %q", err)
+		klog.V(4).Infof("Error getting resctrl path: %q", err)
 	} else {
 		cont.resctrlCollector, err = m.resctrlManager.GetCollector(resctrlPath)
 		if err != nil {
-			klog.Infof("resctrl metrics will not be available for container %s: %s", cont.info.Name, err)
+			klog.V(4).Infof("resctrl metrics will not be available for container %s: %s", cont.info.Name, err)
 		}
 	}
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -45,9 +45,9 @@ import (
 	"github.com/google/cadvisor/utils/sysfs"
 	"github.com/google/cadvisor/version"
 	"github.com/google/cadvisor/watcher"
-	"github.com/opencontainers/runc/libcontainer/cgroups/fs2"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fs2"
 	"github.com/opencontainers/runc/libcontainer/intelrdt"
 
 	"k8s.io/klog/v2"
@@ -932,7 +932,7 @@ func (m *manager) createContainerLocked(containerName string, watchSource watche
 		perfCgroupPath := path.Join(fs2.UnifiedMountpoint, containerName)
 		cont.perfCollector, err = m.perfManager.GetCollector(perfCgroupPath)
 		if err != nil {
-			klog.Infof("perf_event metrics will not be available for container %s: %s", containerName, err)
+			klog.V(4).Infof("perf_event metrics will not be available for container %s: %s", containerName, err)
 		}
 	} else {
 		devicesCgroupPath, err := handler.GetCgroupPath("devices")
@@ -950,7 +950,7 @@ func (m *manager) createContainerLocked(containerName string, watchSource watche
 		} else {
 			cont.perfCollector, err = m.perfManager.GetCollector(perfCgroupPath)
 			if err != nil {
-				klog.Infof("perf_event metrics will not be available for container %s: %s", containerName, err)
+				klog.V(4).Infof("perf_event metrics will not be available for container %s: %s", containerName, err)
 			}
 		}
 	}

--- a/resctrl/manager.go
+++ b/resctrl/manager.go
@@ -18,6 +18,8 @@
 package resctrl
 
 import (
+	"os"
+
 	"github.com/google/cadvisor/stats"
 
 	"github.com/opencontainers/runc/libcontainer/intelrdt"
@@ -29,6 +31,9 @@ type manager struct {
 }
 
 func (m manager) GetCollector(resctrlPath string) (stats.Collector, error) {
+	if _, err := os.Stat(resctrlPath); err != nil {
+		return &stats.NoopCollector{}, err
+	}
 	collector := newCollector(m.id, resctrlPath)
 	return collector, nil
 }


### PR DESCRIPTION
- Change warning for resctrl path to Info with verbosity level
- Change info log to Info with verbosity level
- Change imports grouping
- Add verbosity level to perf Info logs 
- Add checking if resctrl path exists

Without changes introduced in this pull request cAdvisor was very verbose when running without log level verbosity, e.g.:
```
sudo ./cadvisor
W0624 10:56:56.152857   28203 nvidia.go:61] NVIDIA GPU metrics will not be available: no NVIDIA devices found
W0624 10:56:56.167991   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.185596   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.186009   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.186377   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.186792   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.187250   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.187682   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.188096   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.188479   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.188871   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.189269   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.190073   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.190478   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.190865   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.191894   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.192313   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.193188   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.193657   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.194238   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.195086   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.195998   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.196421   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.196792   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.197162   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.197586   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.198173   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.200043   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.200462   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.200908   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.202614   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.203551   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.204001   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.204406   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.204793   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.205176   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.205587   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.206013   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.206344   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.206653   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.207327   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.207885   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.208268   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.208645   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.209024   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.209421   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.210485   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.211085   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.211700   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.212198   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.213704   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.214568   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.215265   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.215692   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.216247   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.216798   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.217740   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.218193   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.218607   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.218983   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
W0624 10:56:56.219795   28203 manager.go:960] Error getting resctrl path: "mountpoint for Intel RDT not found"
```
or 
```
sudo ./cadvisor -perf_events_config=perf/testing/perf-non-hardware.json
W0624 11:14:07.068685   12467 nvidia.go:61] NVIDIA GPU metrics will not be available: no NVIDIA devices found
I0624 11:14:07.167166   12467 manager.go:953] perf_event metrics will not be available for container /system.slice/irqbalance.servic                                         e: unable to open cgroup directory /sys/fs/cgroup/perf_event/system.slice/irqbalance.service: open /sys/fs/cgroup/perf_event/system.                                         slice/irqbalance.service: no such file or directory
I0624 11:14:07.167768   12467 manager.go:953] perf_event metrics will not be available for container /system.slice/whoopsie.service:                                          unable to open cgroup directory /sys/fs/cgroup/perf_event/system.slice/whoopsie.service: open /sys/fs/cgroup/perf_event/system.slic                                         e/whoopsie.service: no such file or directory
I0624 11:14:07.168308   12467 manager.go:953] perf_event metrics will not be available for container /machine/vrsd_vagrant_podm.libv                                         irt-qemu/vcpu6: unable to open cgroup directory /sys/fs/cgroup/perf_event/machine/vrsd_vagrant_podm.libvirt-qemu/vcpu6: open /sys/fs                                         /cgroup/perf_event/machine/vrsd_vagrant_podm.libvirt-qemu/vcpu6: no such file or directory
I0624 11:14:07.169716   12467 manager.go:953] perf_event metrics will not be available for container /docker/84ec42f2210f037bb8463a4                                         1baae2b407c24287b841e1a93c1a3cb6c880e6482/system.slice: unable to open cgroup directory /sys/fs/cgroup/perf_event/docker/84ec42f2210                                         f037bb8463a41baae2b407c24287b841e1a93c1a3cb6c880e6482/system.slice: open /sys/fs/cgroup/perf_event/docker/84ec42f2210f037bb8463a41ba                                         ae2b407c24287b841e1a93c1a3cb6c880e6482/system.slice: no such file or directory
I0624 11:14:07.170307   12467 manager.go:953] perf_event metrics will not be available for container /system.slice/systemd-journal-f                                         lush.service: unable to open cgroup directory /sys/fs/cgroup/perf_event/system.slice/systemd-journal-flush.service: open /sys/fs/cgr                                         oup/perf_event/system.slice/systemd-journal-flush.service: no such file or directory
I0624 11:14:07.170879   12467 manager.go:953] perf_event metrics will not be available for container /system.slice/systemd-remount-f                                         s.service: unable to open cgroup directory /sys/fs/cgroup/perf_event/system.slice/systemd-remount-fs.service: open /sys/fs/cgroup/pe                                         rf_event/system.slice/systemd-remount-fs.service: no such file or directory
```
or 
```
sudo ./cadvisor
W0625 05:07:54.635531   82758 nvidia.go:61] NVIDIA GPU metrics will not be available: no NVIDIA devices found
E0625 05:07:54.763756   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/tuned.service: %!s(<nil>)
W0625 05:07:54.763838   82758 container.go:549] Failed to update stats for container "/system.slice/tuned.service": open /sys/fs/resctrl/system.slice/tuned.service/schemata: no such file or directory
E0625 05:07:54.764950   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/kdump.service: %!s(<nil>)
W0625 05:07:54.765015   82758 container.go:549] Failed to update stats for container "/system.slice/kdump.service": open /sys/fs/resctrl/system.slice/kdump.service/schemata: no such file or directory
E0625 05:07:54.766410   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/lvm2-monitor.service: %!s(<nil>)
W0625 05:07:54.766457   82758 container.go:549] Failed to update stats for container "/system.slice/lvm2-monitor.service": open /sys/fs/resctrl/system.slice/lvm2-monitor.service/schemata: no such file or directory
E0625 05:07:54.767679   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/rhel-domainname.service: %!s(<nil>)
W0625 05:07:54.767723   82758 container.go:549] Failed to update stats for container "/system.slice/rhel-domainname.service": open /sys/fs/resctrl/system.slice/rhel-domainname.service/schemata: no such file or directory
E0625 05:07:54.768895   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/dev-mapper-centos\x2dswap.swap: %!s(<nil>)
W0625 05:07:54.768933   82758 container.go:549] Failed to update stats for container "/system.slice/dev-mapper-centos\x2dswap.swap": open /sys/fs/resctrl/system.slice/dev-mapper-centos\x2dswap.swap/schemata: no such file or directory
E0625 05:07:54.770028   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-readahead-collect.service: %!s(<nil>)
W0625 05:07:54.770065   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-readahead-collect.service": open /sys/fs/resctrl/system.slice/systemd-readahead-collect.service/schemata: no such file or directory
E0625 05:07:54.771904   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/dbus.service: %!s(<nil>)
W0625 05:07:54.771959   82758 container.go:549] Failed to update stats for container "/system.slice/dbus.service": open /sys/fs/resctrl/system.slice/dbus.service/schemata: no such file or directory
E0625 05:07:54.772344   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/sshd.service: %!s(<nil>)
W0625 05:07:54.772385   82758 container.go:549] Failed to update stats for container "/system.slice/sshd.service": open /sys/fs/resctrl/system.slice/sshd.service/schemata: no such file or directory
E0625 05:07:54.773548   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/rsyslog.service: %!s(<nil>)
W0625 05:07:54.773599   82758 container.go:549] Failed to update stats for container "/system.slice/rsyslog.service": open /sys/fs/resctrl/system.slice/rsyslog.service/schemata: no such file or directory
E0625 05:07:54.775561   82758 container.go:685] error occurred while collecting resctrl stats for container /user.slice: %!s(<nil>)
W0625 05:07:54.775613   82758 container.go:549] Failed to update stats for container "/user.slice": open /sys/fs/resctrl/user.slice/schemata: no such file or directory
E0625 05:07:54.777302   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/crond.service: %!s(<nil>)
W0625 05:07:54.777361   82758 container.go:549] Failed to update stats for container "/system.slice/crond.service": open /sys/fs/resctrl/system.slice/crond.service/schemata: no such file or directory
E0625 05:07:54.778806   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-journal-flush.service: %!s(<nil>)
W0625 05:07:54.778858   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-journal-flush.service": open /sys/fs/resctrl/system.slice/systemd-journal-flush.service/schemata: no such file or directory
E0625 05:07:54.779653   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/network.service: %!s(<nil>)
W0625 05:07:54.779697   82758 container.go:549] Failed to update stats for container "/system.slice/network.service": open /sys/fs/resctrl/system.slice/network.service/schemata: no such file or directory
E0625 05:07:54.781024   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-logind.service: %!s(<nil>)
W0625 05:07:54.781079   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-logind.service": open /sys/fs/resctrl/system.slice/systemd-logind.service/schemata: no such file or directory
E0625 05:07:54.792675   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/docker-66499ccdebcd707b5efd93520f7d9403bf730a32f71a8d76dd54609da704f541.scope: %!s(<nil>)
W0625 05:07:54.792739   82758 container.go:549] Failed to update stats for container "/system.slice/docker-66499ccdebcd707b5efd93520f7d9403bf730a32f71a8d76dd54609da704f541.scope": open /sys/fs/resctrl/system.slice/docker-66499ccdebcd707b5efd93520f7d9403bf730a32f71a8d76dd54609da704f541.scope/schemata: no such file or directory
E0625 05:07:54.793346   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-journald.service: %!s(<nil>)
W0625 05:07:54.793410   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-journald.service": open /sys/fs/resctrl/system.slice/systemd-journald.service/schemata: no such file or directory
E0625 05:07:54.794947   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/rhel-readonly.service: %!s(<nil>)
W0625 05:07:54.795002   82758 container.go:549] Failed to update stats for container "/system.slice/rhel-readonly.service": open /sys/fs/resctrl/system.slice/rhel-readonly.service/schemata: no such file or directory
E0625 05:07:54.796533   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/dev-disk-by\x2duuid-ab98f3f7\x2d7fc3\x2d4115\x2da698\x2d7647ca0a40f1.swap: %!s(<nil>)
W0625 05:07:54.796577   82758 container.go:549] Failed to update stats for container "/system.slice/dev-disk-by\x2duuid-ab98f3f7\x2d7fc3\x2d4115\x2da698\x2d7647ca0a40f1.swap": open /sys/fs/resctrl/system.slice/dev-disk-by\x2duuid-ab98f3f7\x2d7fc3\x2d4115\x2da698\x2d7647ca0a40f1.swap/schemata: no such file or directory
E0625 05:07:54.798248   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/dev-disk-by\x2did-dm\x2duuid\x2dLVM\x2dYrd33Sb4N7tNEcEs4rtwa0W3LdKZbZpHYvadixnn79nURGcrI9xCoSPLrYNZHSPF.swap: %!s(<nil>)
W0625 05:07:54.798315   82758 container.go:549] Failed to update stats for container "/system.slice/dev-disk-by\x2did-dm\x2duuid\x2dLVM\x2dYrd33Sb4N7tNEcEs4rtwa0W3LdKZbZpHYvadixnn79nURGcrI9xCoSPLrYNZHSPF.swap": open /sys/fs/resctrl/system.slice/dev-disk-by\x2did-dm\x2duuid\x2dLVM\x2dYrd33Sb4N7tNEcEs4rtwa0W3LdKZbZpHYvadixnn79nURGcrI9xCoSPLrYNZHSPF.swap/schemata: no such file or directory
E0625 05:07:54.799554   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-vconsole-setup.service: %!s(<nil>)
W0625 05:07:54.799598   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-vconsole-setup.service": open /sys/fs/resctrl/system.slice/systemd-vconsole-setup.service/schemata: no such file or directory
E0625 05:07:54.800913   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-readahead-replay.service: %!s(<nil>)
W0625 05:07:54.800956   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-readahead-replay.service": open /sys/fs/resctrl/system.slice/systemd-readahead-replay.service/schemata: no such file or directory
E0625 05:07:54.802351   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/rhel-import-state.service: %!s(<nil>)
W0625 05:07:54.802404   82758 container.go:549] Failed to update stats for container "/system.slice/rhel-import-state.service": open /sys/fs/resctrl/system.slice/rhel-import-state.service/schemata: no such file or directory
E0625 05:07:54.803235   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/polkit.service: %!s(<nil>)
W0625 05:07:54.803273   82758 container.go:549] Failed to update stats for container "/system.slice/polkit.service": open /sys/fs/resctrl/system.slice/polkit.service/schemata: no such file or directory
E0625 05:07:54.806410   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/system-lvm2\x2dpvscan.slice: %!s(<nil>)
W0625 05:07:54.806480   82758 container.go:549] Failed to update stats for container "/system.slice/system-lvm2\x2dpvscan.slice": open /sys/fs/resctrl/system.slice/system-lvm2\x2dpvscan.slice/schemata: no such file or directory
E0625 05:07:54.807929   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-random-seed.service: %!s(<nil>)
W0625 05:07:54.807994   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-random-seed.service": open /sys/fs/resctrl/system.slice/systemd-random-seed.service/schemata: no such file or directory
E0625 05:07:54.809068   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/dev-dm\x2d1.swap: %!s(<nil>)
W0625 05:07:54.809169   82758 container.go:549] Failed to update stats for container "/system.slice/dev-dm\x2d1.swap": open /sys/fs/resctrl/system.slice/dev-dm\x2d1.swap/schemata: no such file or directory
E0625 05:07:54.810808   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/lvm2-lvmetad.service: %!s(<nil>)
W0625 05:07:54.810852   82758 container.go:549] Failed to update stats for container "/system.slice/lvm2-lvmetad.service": open /sys/fs/resctrl/system.slice/lvm2-lvmetad.service/schemata: no such file or directory
E0625 05:07:54.812011   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/NetworkManager.service: %!s(<nil>)
W0625 05:07:54.812055   82758 container.go:549] Failed to update stats for container "/system.slice/NetworkManager.service": open /sys/fs/resctrl/system.slice/NetworkManager.service/schemata: no such file or directory
E0625 05:07:54.813548   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/dev-centos-swap.swap: %!s(<nil>)
W0625 05:07:54.813593   82758 container.go:549] Failed to update stats for container "/system.slice/dev-centos-swap.swap": open /sys/fs/resctrl/system.slice/dev-centos-swap.swap/schemata: no such file or directory
E0625 05:07:54.815109   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/postfix.service: %!s(<nil>)
W0625 05:07:54.815160   82758 container.go:549] Failed to update stats for container "/system.slice/postfix.service": open /sys/fs/resctrl/system.slice/postfix.service/schemata: no such file or directory
E0625 05:07:54.816628   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/rhel-dmesg.service: %!s(<nil>)
W0625 05:07:54.816671   82758 container.go:549] Failed to update stats for container "/system.slice/rhel-dmesg.service": open /sys/fs/resctrl/system.slice/rhel-dmesg.service/schemata: no such file or directory
E0625 05:07:54.818118   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-tmpfiles-setup-dev.service: %!s(<nil>)
W0625 05:07:54.818167   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-tmpfiles-setup-dev.service": open /sys/fs/resctrl/system.slice/systemd-tmpfiles-setup-dev.service/schemata: no such file or directory
E0625 05:07:54.819735   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-sysctl.service: %!s(<nil>)
W0625 05:07:54.819785   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-sysctl.service": open /sys/fs/resctrl/system.slice/systemd-sysctl.service/schemata: no such file or directory
E0625 05:07:54.820630   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/system-selinux\x2dpolicy\x2dmigrate\x2dlocal\x2dchanges.slice: %!s(<nil>)
W0625 05:07:54.820667   82758 container.go:549] Failed to update stats for container "/system.slice/system-selinux\x2dpolicy\x2dmigrate\x2dlocal\x2dchanges.slice": open /sys/fs/resctrl/system.slice/system-selinux\x2dpolicy\x2dmigrate\x2dlocal\x2dchanges.slice/schemata: no such file or directory
E0625 05:07:54.823106   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/irqbalance.service: %!s(<nil>)
W0625 05:07:54.823155   82758 container.go:549] Failed to update stats for container "/system.slice/irqbalance.service": open /sys/fs/resctrl/system.slice/irqbalance.service/schemata: no such file or directory
E0625 05:07:54.823982   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice: %!s(<nil>)
W0625 05:07:54.824025   82758 container.go:549] Failed to update stats for container "/system.slice": open /sys/fs/resctrl/system.slice/schemata: no such file or directory
E0625 05:07:54.824449   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-update-utmp.service: %!s(<nil>)
W0625 05:07:54.824540   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-update-utmp.service": open /sys/fs/resctrl/system.slice/systemd-update-utmp.service/schemata: no such file or directory
E0625 05:07:54.825052   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/auditd.service: %!s(<nil>)
W0625 05:07:54.825119   82758 container.go:549] Failed to update stats for container "/system.slice/auditd.service": open /sys/fs/resctrl/system.slice/auditd.service/schemata: no such file or directory
E0625 05:07:54.826717   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/pcscd.service: %!s(<nil>)
W0625 05:07:54.826776   82758 container.go:549] Failed to update stats for container "/system.slice/pcscd.service": open /sys/fs/resctrl/system.slice/pcscd.service/schemata: no such file or directory
E0625 05:07:54.827118   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/firewalld.service: %!s(<nil>)
W0625 05:07:54.827168   82758 container.go:549] Failed to update stats for container "/system.slice/firewalld.service": open /sys/fs/resctrl/system.slice/firewalld.service/schemata: no such file or directory
E0625 05:07:54.829605   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/system-getty.slice: %!s(<nil>)
W0625 05:07:54.829645   82758 container.go:549] Failed to update stats for container "/system.slice/system-getty.slice": open /sys/fs/resctrl/system.slice/system-getty.slice/schemata: no such file or directory
E0625 05:07:54.831375   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/docker.service: %!s(<nil>)
W0625 05:07:54.831426   82758 container.go:549] Failed to update stats for container "/system.slice/docker.service": open /sys/fs/resctrl/system.slice/docker.service/schemata: no such file or directory
E0625 05:07:54.833138   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-tmpfiles-setup.service: %!s(<nil>)
W0625 05:07:54.833192   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-tmpfiles-setup.service": open /sys/fs/resctrl/system.slice/systemd-tmpfiles-setup.service/schemata: no such file or directory
E0625 05:07:54.834635   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-udev-trigger.service: %!s(<nil>)
W0625 05:07:54.834676   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-udev-trigger.service": open /sys/fs/resctrl/system.slice/systemd-udev-trigger.service/schemata: no such file or directory
E0625 05:07:54.836380   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/NetworkManager-wait-online.service: %!s(<nil>)
W0625 05:07:54.836438   82758 container.go:549] Failed to update stats for container "/system.slice/NetworkManager-wait-online.service": open /sys/fs/resctrl/system.slice/NetworkManager-wait-online.service/schemata: no such file or directory
E0625 05:07:54.836885   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/kmod-static-nodes.service: %!s(<nil>)
W0625 05:07:54.836911   82758 container.go:549] Failed to update stats for container "/system.slice/kmod-static-nodes.service": open /sys/fs/resctrl/system.slice/kmod-static-nodes.service/schemata: no such file or directory
E0625 05:07:54.839072   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-remount-fs.service: %!s(<nil>)
W0625 05:07:54.839112   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-remount-fs.service": open /sys/fs/resctrl/system.slice/systemd-remount-fs.service/schemata: no such file or directory
E0625 05:07:54.839922   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/dev-disk-by\x2did-dm\x2dname\x2dcentos\x2dswap.swap: %!s(<nil>)
W0625 05:07:54.839953   82758 container.go:549] Failed to update stats for container "/system.slice/dev-disk-by\x2did-dm\x2dname\x2dcentos\x2dswap.swap": open /sys/fs/resctrl/system.slice/dev-disk-by\x2did-dm\x2dname\x2dcentos\x2dswap.swap/schemata: no such file or directory
E0625 05:07:54.841931   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-user-sessions.service: %!s(<nil>)
W0625 05:07:54.841970   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-user-sessions.service": open /sys/fs/resctrl/system.slice/systemd-user-sessions.service/schemata: no such file or directory
E0625 05:07:54.842327   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-udevd.service: %!s(<nil>)
W0625 05:07:54.842351   82758 container.go:549] Failed to update stats for container "/system.slice/systemd-udevd.service": open /sys/fs/resctrl/system.slice/systemd-udevd.service/schemata: no such file or directory
E0625 05:07:55.838260   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-readahead-collect.service: %!s(<nil>)
E0625 05:07:55.846769   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/rhel-dmesg.service: %!s(<nil>)
E0625 05:07:55.871223   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/sshd.service: %!s(<nil>)
E0625 05:07:55.885507   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-update-utmp.service: %!s(<nil>)
E0625 05:07:55.904612   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/irqbalance.service: %!s(<nil>)
E0625 05:07:55.931467   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/dbus.service: %!s(<nil>)
E0625 05:07:55.978628   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-tmpfiles-setup-dev.service: %!s(<nil>)
E0625 05:07:55.995216   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-journal-flush.service: %!s(<nil>)
E0625 05:07:56.003380   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/firewalld.service: %!s(<nil>)
E0625 05:07:56.004841   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-vconsole-setup.service: %!s(<nil>)
E0625 05:07:56.018862   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/dev-disk-by\x2did-dm\x2duuid\x2dLVM\x2dYrd33Sb4N7tNEcEs4rtwa0W3LdKZbZpHYvadixnn79nURGcrI9xCoSPLrYNZHSPF.swap: %!s(<nil>)
E0625 05:07:56.019736   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/lvm2-lvmetad.service: %!s(<nil>)
E0625 05:07:56.078607   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-journald.service: %!s(<nil>)
E0625 05:07:56.079557   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/rsyslog.service: %!s(<nil>)
E0625 05:07:56.090206   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/rhel-readonly.service: %!s(<nil>)
E0625 05:07:56.092334   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/kmod-static-nodes.service: %!s(<nil>)
E0625 05:07:56.101095   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-logind.service: %!s(<nil>)
E0625 05:07:56.101962   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/system-lvm2\x2dpvscan.slice: %!s(<nil>)
E0625 05:07:56.106877   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-random-seed.service: %!s(<nil>)
E0625 05:07:56.113759   82758 container.go:685] error occurred while collecting resctrl stats for container /system.slice/systemd-tmpfiles-setup.service: %!s(<nil>)
```